### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=An Arduino library to interface the MAX7219 series chip to control any 
 paragraph=See README on https://github.com/MikeDX/MAX7219
 category=Device Control
 url=https://github.com/MikeDX/MAX7219
-architectures=atmelavr, expressif, esp8266
+architectures=avr, atmelavr, expressif, esp8266
 includes=max7219.h


### PR DESCRIPTION
The previous architectures value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library MAX7219 claims to run on (ARCHITECTURE) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the File > Examples > INCOMPATIBLE menu.